### PR TITLE
Only show the table of contents if it's non-empty

### DIFF
--- a/gov_au_theme/base.html
+++ b/gov_au_theme/base.html
@@ -132,7 +132,7 @@
         {% endif %}
       {% endif %}
     </header>
-      {% if toc %}
+      {% if toc and toc|list|length > 0 %}
       <nav class="index-links">
       <h2>In this section</h2>
         <ul>


### PR DESCRIPTION
## Before

![image](https://cloud.githubusercontent.com/assets/4583474/20126245/b0728b22-a687-11e6-93ef-839e54c682e6.png)

## After

![image](https://cloud.githubusercontent.com/assets/4583474/20126248/b6be3152-a687-11e6-969f-cca4a5817b2d.png)
